### PR TITLE
Add ability to customize bar colors

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using Dalamud.Configuration;
 using Dalamud.Plugin;
 using Newtonsoft.Json;
@@ -15,6 +16,10 @@ namespace MPTimer {
         public bool AlwaysShowWithHostileTarget { get; set; }
         public Vector2 BarSize { get; set; } = new Vector2(190, 40);
         public Vector2 BarPosition { get; set; } = new Vector2(800, 500);
+        public Vector4 FireThresholdColor { get; set; } = new Vector4(1f, 0.650f, 0.133f, 1f);
+        public Vector4 BarBorderColor { get; set; } = new Vector4(0.451f, 0.796f, 0.969f, 1f);
+        public Vector4 BarBackgroundColor { get; set; } = new Vector4(0.031f, 0.173f, 0.332f, 1f);
+        public Vector4 BarFillColor { get; set; } = new Vector4(1f, 1f, 1f, 1f);
 
         [JsonIgnore] private DalamudPluginInterface pluginInterface;
 
@@ -24,6 +29,14 @@ namespace MPTimer {
 
         public void Save() {
             this.pluginInterface.SavePluginConfig(this);
+        }
+
+        public void ResetPropertyToDefault(string colorProp) {
+            var configType = this.GetType();
+            var instance = Activator.CreateInstance(configType);
+            var defaultValue = configType.GetProperty(colorProp)?.GetValue(instance);
+            configType.GetProperty(colorProp)?.SetValue(this, defaultValue);
+            this.Save();
         }
     }
 }


### PR DESCRIPTION
Adds the ability to customize the bar border, background, fill, and Fire3 threshold colors, and reorganizes the config window to better accommodate additional settings.  Also addresses an issue wherein the bar background rect was slightly offset, leaving a one-pixel gap between the bottom right border and the background.

![image](https://user-images.githubusercontent.com/52226546/129487475-178aef3b-4b3e-40da-ad63-e550b3d672d4.png)
